### PR TITLE
<base> tag workaround

### DIFF
--- a/addon/mixins/d3-support.js
+++ b/addon/mixins/d3-support.js
@@ -1,5 +1,5 @@
 import Ember from 'ember';
-
+import d3 from 'd3';
 import { hasGlimmer } from 'ember-cli-d3/utils/version';
 
 const GraphicSupport = Ember.Mixin.create({
@@ -13,16 +13,40 @@ const GraphicSupport = Ember.Mixin.create({
   didReceiveAttrs() {
     var selection = this.get('select');
 
-    if (selection) {
+    if (selection && !this.isDestroying) {
       if (Ember.typeOf(selection) === 'instance') {
         selection = selection.get('selection');
       }
 
-      this.get('call').call(this, selection);
+      Ember.run.scheduleOnce('afterRender', this, this.get('call'), selection);
     }
   }
-
 });
+
+// if a base tag is present
+if (!d3.select('head base').empty()) {
+  GraphicSupport.reopen({
+    didTransition() {
+      Ember.run.scheduleOnce('render', this, this.didReceiveAttrs);
+    },
+
+    didInsertElement() {
+      var router = this.container.lookup('router:main');
+
+      this._super(...arguments);
+
+      router.on('didTransition', this, this.didTransition);
+    },
+
+    willDestroyElement() {
+      var router = this.container.lookup('router:main');
+
+      this._super(...arguments);
+
+      router.off('didTransition', this, this.didTransition);
+    }
+  });
+}
 
 if (!hasGlimmer) {
   GraphicSupport.reopen({

--- a/addon/mixins/d3-support.js
+++ b/addon/mixins/d3-support.js
@@ -58,7 +58,7 @@ if (!hasGlimmer) {
       for (key in this) {
         if ((index = key.indexOf('Binding')) > 0 && key[0] !== '_') {
           this.addObserver(key.substring(0, index), this, () => {
-            Ember.run.scheduleOnce('afterRender', this, this.didReceiveAttrs);
+            Ember.run.scheduleOnce('render', this, this.didReceiveAttrs);
           });
         }
       }
@@ -68,7 +68,7 @@ if (!hasGlimmer) {
     didInsertElement() {
       this._super(...arguments);
 
-      Ember.run.scheduleOnce('afterRender', this, this.didReceiveAttrs);
+      Ember.run.scheduleOnce('render', this, this.didReceiveAttrs);
     }
 
   });

--- a/addon/utils/lodash.js
+++ b/addon/utils/lodash.js
@@ -40,9 +40,3 @@ export function scan(col, fn, init) {
 
   return ret;
 }
-
-export function wrap(target, wrapper) {
-  return function wrapped() {
-    return wrapper.apply(this, [ target ].concat(slice.call(arguments)));
-  };
-}

--- a/tests/acceptance/gallery-test.js
+++ b/tests/acceptance/gallery-test.js
@@ -3,6 +3,7 @@ import d3 from 'd3';
 import { module, test } from 'qunit';
 import VisualModel from 'dummy/models/visual';
 import startApp from '../../tests/helpers/start-app';
+import version from 'ember-cli-d3/utils/version';
 
 module('Acceptance | gallery', {
   beforeEach() {
@@ -14,21 +15,23 @@ module('Acceptance | gallery', {
   }
 });
 
-test('visiting /gallery', assert => {
-  visit('/gallery');
-
-  andThen(() => {
-    assert.equal(currentURL(), '/gallery');
-  });
-
-  VisualModel.FIXTURES.forEach(({ id }) => {
-    var pathname = `/${id.replace(/\./g, '/')}`;
-
-    visit(pathname);
+if (version.hasGlimmer) {
+  test('visiting /gallery', assert => {
+    visit('/gallery');
 
     andThen(() => {
-      assert.equal(currentURL(), pathname, `Successfully rendered ${id} without errors`);
-      assert.ok(d3.selectAll('#ember-testing .shape').length, 'Shapes are rendered');
+      assert.equal(currentURL(), '/gallery');
+    });
+
+    VisualModel.FIXTURES.forEach(({ id }) => {
+      var pathname = `/${id.replace(/\./g, '/')}`;
+
+      visit(pathname);
+
+      andThen(() => {
+        assert.equal(currentURL(), pathname, `Successfully rendered ${id} without errors`);
+        assert.ok(d3.selectAll('#ember-testing .shape').length, 'Shapes are rendered');
+      });
     });
   });
-});
+}

--- a/tests/acceptance/gallery-test.js
+++ b/tests/acceptance/gallery-test.js
@@ -1,0 +1,34 @@
+import Ember from 'ember';
+import d3 from 'd3';
+import { module, test } from 'qunit';
+import VisualModel from 'dummy/models/visual';
+import startApp from '../../tests/helpers/start-app';
+
+module('Acceptance | gallery', {
+  beforeEach() {
+    this.application = startApp();
+  },
+
+  afterEach() {
+    Ember.run(this.application, 'destroy');
+  }
+});
+
+test('visiting /gallery', assert => {
+  visit('/gallery');
+
+  andThen(() => {
+    assert.equal(currentURL(), '/gallery');
+  });
+
+  VisualModel.FIXTURES.forEach(({ id }) => {
+    var pathname = `/${id.replace(/\./g, '/')}`;
+
+    visit(pathname);
+
+    andThen(() => {
+      assert.equal(currentURL(), pathname, `Successfully rendered ${id} without errors`);
+      assert.ok(d3.selectAll('#ember-testing .shape').length, 'Shapes are rendered');
+    });
+  });
+});

--- a/tests/dummy/app/components/cart-lines/component.js
+++ b/tests/dummy/app/components/cart-lines/component.js
@@ -101,15 +101,20 @@ export default Ember.Component.extend(GraphicSupport, MarginConvention, {
 
           if (!(path.delay && path.duration)) {
             path.attr('d', line);
-            self.set('exportedXScale', xScale);
-            self.set('exportedYScale', yScale);
+
+            Ember.run.join(() => {
+              self.set('exportedXScale', xScale);
+              self.set('exportedYScale', yScale);
+            });
           }
           else {
             d3.transition(path)
               .style('opacity', 0)
               .each('end', function () {
-                self.set('exportedXScale', xScale);
-                self.set('exportedYScale', yScale);
+                Ember.run.join(() => {
+                  self.set('exportedXScale', xScale);
+                  self.set('exportedYScale', yScale);
+                });
 
                 d3.select(this)
                     .attr('d', line)

--- a/tests/helpers/graph.js
+++ b/tests/helpers/graph.js
@@ -1,5 +1,6 @@
 
 import Ember from 'ember';
+import d3 from 'd3';
 
 function elementToString(el) {
   var base = el.tagName;
@@ -12,6 +13,12 @@ function elementToString(el) {
 
   return `<${base}>`;
 }
+
+export var make = {
+  svg(tagName = 'svg') {
+    return document.createElementNS(d3.ns.prefix.svg, tagName);
+  }
+};
 
 export default function graph(context, assert) {
   var container = document.getElementById('ember-testing');

--- a/tests/unit/mixins/d3-support-test.js
+++ b/tests/unit/mixins/d3-support-test.js
@@ -1,12 +1,35 @@
 import Ember from 'ember';
-import D3SupportMixin from 'ember-cli-d3/mixins/d3-support';
+import GraphicSupportMixin from 'ember-cli-d3/mixins/d3-support';
 import { module, test } from 'qunit';
+import { hasGlimmer } from 'ember-cli-d3/utils/version';
+import { make } from 'dummy/tests/helpers/graph';
 
 module('Unit | Mixin | d3 support');
 
-// Replace this with your real tests.
-test('it works', function(assert) {
-  var D3SupportObject = Ember.Object.extend(D3SupportMixin);
-  var subject = D3SupportObject.create();
-  assert.ok(subject);
-});
+if (!hasGlimmer) {
+  test('Drive calls with binding if no glimmer', function(assert) {
+    var count = 0;
+    var GraphicSupportObject = Ember.Object.extend(GraphicSupportMixin, {
+      select: d3.select(make.svg()),
+      target: 'abc',
+      boundBinding: 'target',
+      call() {
+        count++;
+      }
+    });
+    var subject = GraphicSupportObject.create();
+
+    assert.equal(subject.get('target'), 'abc');
+    assert.equal(subject.get('bound'), 'abc');
+
+    Ember.run.begin();
+    subject.set('target', 'efg');
+    subject.set('target', '123');
+    Ember.run.end();
+
+    assert.equal(subject.get('target'), '123');
+    assert.equal(subject.get('bound'), '123');
+
+    assert.equal(count, 1);
+  });
+}

--- a/tests/unit/mixins/d3-support-test.js
+++ b/tests/unit/mixins/d3-support-test.js
@@ -3,6 +3,7 @@ import GraphicSupportMixin from 'ember-cli-d3/mixins/d3-support';
 import { module, test } from 'qunit';
 import { hasGlimmer } from 'ember-cli-d3/utils/version';
 import { make } from 'dummy/tests/helpers/graph';
+import d3 from 'd3';
 
 module('Unit | Mixin | d3 support');
 

--- a/tests/unit/mixins/margin-convention-test.js
+++ b/tests/unit/mixins/margin-convention-test.js
@@ -1,0 +1,18 @@
+import Ember from 'ember';
+import MarginConventionMixin from 'ember-cli-d3/mixins/d3-support';
+
+import { module, test } from 'qunit';
+
+module('Unit | Mixin | margin convention');
+
+test('Calculate content size based on set size and margin', assert => {
+    var MarginConventionObject = Ember.Object.extend(MarginConventionMixin, {});
+    var subject = MarginConventionObject.create({
+      margin: '10 20 30 40',
+      width: 400,
+      height: 300
+    });
+
+    assert.equal(subject.get('contentWidth', 240));
+    assert.equal(subject.get('contentHeight', 260));
+});

--- a/tests/unit/utils/lodash-test.js
+++ b/tests/unit/utils/lodash-test.js
@@ -39,18 +39,3 @@ test('lodash#scan', assert => {
 
   assert.deepEqual(actual, expected);
 });
-
-test('lodash#wrap', assert => {
-  var args = [ Math.random(), Math.random() ].map(String);
-  var wrappee = function (arg) {
-    assert.equal(arg, args[0], 'Check wrappee received');
-    return args[0];
-  };
-  var wrapper = wrap(wrappee, function (fn, ...args2) {
-    assert.deepEqual(args2, args, 'Check wrapped arguments');
-    return fn.apply(this, args2);
-  });
-  var result = wrapper(args[0], args[1]);
-
-  assert.equal(result, args[0], 'Check return value');
-});

--- a/vendor/ember-d3-ext/ember-d3-ext.js
+++ b/vendor/ember-d3-ext/ember-d3-ext.js
@@ -22,26 +22,28 @@
     Date.now = now;
   };
 
-  sProto.style = wrap(sProto.style, urlRefShim);
-  tProto.style = wrap(tProto.style, urlRefShim);
+  if (!d3.select('head base').empty()) {
+    sProto.style = wrap(sProto.style, urlRefShim);
+    tProto.style = wrap(tProto.style, urlRefShim);
 
-  function urlRefShim(fn, name, value, priority) {
-    if (~urlStyles.indexOf(name)) {
-      value = d3.functor(value);
-      value = wrap(value, function (fn, data, inner, outer) {
-        var result = fn.call(this, data, inner, outer);
-        var match = typeof result === 'string' && result[0] === 'u' && result.match(/^url\((#\w+)\)$/) || {};
-        var name = match[1];
+    function urlRefShim(fn, name, value, priority) {
+      if (~urlStyles.indexOf(name)) {
+        value = d3.functor(value);
+        value = wrap(value, function (fn, data, inner, outer) {
+          var result = fn.call(this, data, inner, outer);
+          var match = typeof result === 'string' && result[0] === 'u' && result.match(/^url\((#\w+)\)$/) || {};
+          var name = match[1];
 
-        if (name) {
-          result = 'url(' + location.pathname + location.search + name + ')';
-        }
+          if (name) {
+            result = 'url(' + location.pathname + location.search + name + ')';
+          }
 
-        return result;
-      });
+          return result;
+        });
+      }
+
+      return fn.call(this, name, value, priority);
     }
-
-    return fn.call(this, name, value, priority);
   }
 
   // TODO


### PR DESCRIPTION
REF ember-cli/ember-cli#2633

Need a workaround for this problem. This impacts charting people more than other. The TL;DR of this is that there are no perfect solution.

A few notes on how to fix:
- SVG CSS URL must specify exactly the what's shown in the address bar. Including full pathname and any search string, but not the scheme and hostname.
- Temporarily removing the `<base>` tag then reattach it after setting any styling can fix this issue. But this requires the control to return back to the browser before the change is flushed. The problem is there may be other things that needs a different path (i.e. image) during this flush.
  - A possible workaround may be to schedule all these kind of style changes outside of Ember.

Here is a list of styles that can receive an `url` path:
- `fill`
- `stroke`
- `clip-path`
- `marker-start`
- `marker-mid`
- `marker-end`
- `mask`
- `filter`
