### PR TITLE
Make d3-support compatible with pre-1.13.9 versions of Ember

### DIFF
--- a/addon/mixins/d3-support.js
+++ b/addon/mixins/d3-support.js
@@ -14,6 +14,7 @@ const GraphicSupport = Ember.Mixin.create({
   call() {},
 
   didReceiveAttrs() {
+    this._super(...arguments);
     var selection = this.get('select');
 
     if (selection && !this.isDestroying && this.get('requiredProperties').map(prop => Boolean(!!this.get(prop))).reduce(((prev, cur) => prev && cur), true)) {


### PR DESCRIPTION
d3-support depends on [Ember BUGFIX #12138](https://github.com/emberjs/ember.js/pull/12138), so the library doesn't currently support older versions of ember. Even after the bugfix it is still advised to call _super in didReceiveAttrs, so I added it. This should fix it for older versions.
