### PR TITLE
Fix 'ReferenceError: urlRefShim is not defined' on Firefox 42

### DIFF
--- a/vendor/ember-d3-ext/ember-d3-ext.js
+++ b/vendor/ember-d3-ext/ember-d3-ext.js
@@ -23,11 +23,6 @@
   };
 
   if (!d3.select('head base').empty()) {
-    sProto.style = wrap(sProto.style, urlRefShim);
-    tProto.style = wrap(tProto.style, urlRefShim);
-    sProto.attr = wrap(sProto.attr, urlRefShim);
-    tProto.attr = wrap(tProto.attr, urlRefShim);
-
     function urlRefShim(fn, name, value, priority) {
       if (~urlStyles.indexOf(name)) {
         value = d3.functor(value);
@@ -46,6 +41,11 @@
 
       return fn.call(this, name, value, priority);
     }
+    
+    sProto.style = wrap(sProto.style, urlRefShim);
+    tProto.style = wrap(tProto.style, urlRefShim);
+    sProto.attr = wrap(sProto.attr, urlRefShim);
+    tProto.attr = wrap(tProto.attr, urlRefShim);
   }
 
   // TODO


### PR DESCRIPTION
This shouldn't fix it, but it does. Looks like function variable hoisting is weird on Firefox.
