### PR TITLE
Remove Ember 2.3 deprecation and add polyfill

### DIFF
--- a/addon/mixins/d3-support.js
+++ b/addon/mixins/d3-support.js
@@ -1,4 +1,5 @@
 import Ember from 'ember';
+import getOwner from 'ember-getowner-polyfill';
 import d3 from 'd3';
 import { hasGlimmer } from 'ember-cli-d3/utils/version';
 
@@ -31,7 +32,7 @@ if (!d3.select('head base').empty()) {
     },
 
     didInsertElement() {
-      var router = this.container.lookup('router:main');
+      var router = getOwner(this).lookup('router:main');
 
       this._super(...arguments);
 
@@ -39,7 +40,7 @@ if (!d3.select('head base').empty()) {
     },
 
     willDestroyElement() {
-      var router = this.container.lookup('router:main');
+      var router = getOwner(this).lookup('router:main');
 
       this._super(...arguments);
 
@@ -76,7 +77,7 @@ if (!hasGlimmer) {
 else {
   GraphicSupport.reopen({
     didInsertElement() {
-      var index = this.container.lookup("-view-registry:main");
+      var index = getOwner(this).lookup("-view-registry:main");
 
       this._super(...arguments);
 
@@ -84,7 +85,7 @@ else {
     },
 
     willDestroyElement() {
-      var index = this.container.lookup("-view-registry:main");
+      var index = getOwner(this).lookup("-view-registry:main");
 
       this._super(...arguments);
 

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "ember-disable-prototype-extensions": "^1.0.0",
     "ember-disable-proxy-controllers": "^1.0.0",
     "ember-export-application-global": "^1.0.2",
+    "ember-getowner-polyfill": "1.0.0",
     "ember-try": "0.0.8"
   },
   "keywords": [

--- a/tests/integration/components/cart-grouped-bars-test.js
+++ b/tests/integration/components/cart-grouped-bars-test.js
@@ -1,4 +1,5 @@
 import d3 from 'd3';
+import getOwner from 'ember-getowner-polyfill';
 import { dimensional } from 'dummy/tests/helpers/data-generator';
 import { moduleForComponent, test } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
@@ -9,7 +10,7 @@ moduleForComponent('cart-grouped-bars', 'Integration | Component | cart grouped 
 });
 
 test('it renders alone', function(assert) {
-  let source = this.container.lookup('service:dimensional-data-source');
+  let source = getOwner(this).lookup('service:dimensional-data-source');
   let model = source.get('crossSectionModel');
 
   return graph(this, assert)


### PR DESCRIPTION
Here's the description of deprecation:
http://emberjs.com/deprecations/v2.x/#toc_injected-container-access
