### PR TITLE
Remove explicit layout in data-visual component

### DIFF
--- a/addon/components/data-visual.js
+++ b/addon/components/data-visual.js
@@ -1,11 +1,9 @@
 import Ember from 'ember';
-import layout from '../templates/components/data-visual';
 
 import Stage from '../system/stage';
 
 export default Ember.Component.extend({
   classNames: [ 'data-visual' ],
-  layout,
 
   width: 300,
   height: 150,


### PR DESCRIPTION
The `import` is too eager to load the template, and the template request HTMLBars to be present. This causes compatibility issue with lower Ember version.
