### PR TITLE
Fix urlRefShim to pass through correct number of arguments

### DIFF
--- a/vendor/ember-d3-ext/ember-d3-ext.js
+++ b/vendor/ember-d3-ext/ember-d3-ext.js
@@ -39,7 +39,7 @@
         });
       }
 
-      return fn.call(this, name, value, priority);
+      return fn.apply(this, slice.call(arguments, 1));
     }
     
     sProto.style = wrap(sProto.style, urlRefShim);


### PR DESCRIPTION
Hi,

I noticed a problem with the url shim - if you call e.g. `selection.style("cursor")` as an accessor, this gets translated by the shim into `selection.style("cursor", null)` which then actually modifies the value.

This particularly causes problems for the brush examples - the cursor styles disappear.

This should fix it - let me know if you need any more tests/explanation, etc.

Thanks for the project!
