### PR TITLE
Fix weird problem where classList is null not empty array

### DIFF
--- a/addon/system/selection-proxy.js
+++ b/addon/system/selection-proxy.js
@@ -30,7 +30,7 @@ const SelectionProxy = Ember.Object.extend({
     let node = (SelectionProxy.detectInstance(selection) ? selection.get('selection') : selection).node();
     let tagName = node.tagName;
     let id = node.id ? `#${node.id}` : '';
-    let cls = node.classList[0] ? `.${node.classList[0]}` : '';
+    let cls = (node.classList && node.classList[0]) ? `.${node.classList[0]}` : '';
 
     return `<ember-cli-d3@selection-proxy:${guid}::${tagName}${id}${cls}>`;
   }


### PR DESCRIPTION
Hey,

I found a strange bug when running with phantomjs in headless mode while running on Codeship where `node.classList` was undefined rather than `[]`, which caused everything to blow up with `TypeError: 'undefined' is not an object (evaluating 'node.classList[0]')`. This simple check fixes the problem.

Let me know if you have any questions about it.
