### PR TITLE
check if app options exist in included hook

### DIFF
--- a/index.js
+++ b/index.js
@@ -49,7 +49,8 @@ module.exports = {
     });
   },
   included: function(app) {
-    var options = app.options.d3 || {};
+    var appOptions = app.options || {};
+    var options = appOptions.d3 || {};
 
     var plugins = (function () {
       var list = options.plugins || {};


### PR DESCRIPTION
Make sure that included hook does not crash, for apps using an older ember-cli version.